### PR TITLE
Remove unnecessary duplicate URL matches

### DIFF
--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -19,9 +19,7 @@
     {
       "matches": [
         "https://www.instagram.com/*",
-        "https://www.instagram.com/",
-        "https://instagram.com/*",
-        "https://instagram.com/"
+        "https://instagram.com/*"
       ],
       "js": [
         "/assets/js/content.js"


### PR DESCRIPTION
As described in the table [here](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns#examples), the * means zero or more characters:

*://*.mozilla.org/*

Match all HTTP, HTTPS and WebSocket URLs that are hosted at "mozilla.org" or one of its subdomains. 

Which would mean that https://instagram.com/ falls under the https://instagram.com/* match